### PR TITLE
Added ability to adjust aspect ratio

### DIFF
--- a/assets/css/mic-admin.css
+++ b/assets/css/mic-admin.css
@@ -99,3 +99,11 @@
 .mic-option {
 	margin-top: 10px;
 }
+
+.dimensions-width {
+	width: 50px;
+}
+
+.dimensions-height {
+	width: 50px;
+}

--- a/assets/js/microp.js
+++ b/assets/js/microp.js
@@ -1,5 +1,5 @@
 var jcrop_api, mic_attachment_id, mic_edited_size, mic_preview_scale;
-	
+
 jQuery(document).ready(function($) {
 	//image sizes tabs
 	$(document).on('click', '.rm-crop-size-tab', function(e) {
@@ -9,11 +9,19 @@ jQuery(document).ready(function($) {
 			$('#TB_ajaxContent').html(data);
 		});
 	});
-	
+
 	$( document ).on('click', '#micCropImage', function() {
 		$('#micCropImage').hide();
 		$('#micLoading').show();
-		$.post(ajaxurl + '?action=mic_crop_image', { select: jcrop_api.tellSelect(), scaled: jcrop_api.tellScaled(), attachmentId: mic_attachment_id, editedSize: mic_edited_size,  previewScale: mic_preview_scale, make2x: $('#mic-make-2x').prop('checked'), mic_quality: $('#micQuality').val() } ,  function(response) {
+		$.post(ajaxurl + '?action=mic_crop_image', {
+			select: jcrop_api.tellSelect(),
+			scaled: jcrop_api.tellScaled(),
+			attachmentId: mic_attachment_id,
+			editedSize: mic_edited_size,
+			previewScale: mic_preview_scale,
+			make2x: $('#mic-make-2x').prop('checked'),
+			mic_quality: $('#micQuality').val() 
+		} ,  function(response) {
 			if (response.status == 'ok') {
 				var newImage = new Image();
 				newImage.src = response.file + '?' + Math.random();
@@ -37,15 +45,15 @@ jQuery(document).ready(function($) {
 			}
 		}, 'json');
 	});
-	
+
 	 $('.mic-link').click( function() {
 		tb_position();
 	});
-	 
+
 	 $(document).on('click', '#TB_closeWindowButton, .TB_overlayBG', function(e) {
 		 $('#TB_overlay,#TB_window').remove();
 	 });
-	 
+
 	 function adjustMicWindowSize() {
 		 	if( ! $('#TB_ajaxContent .mic-editor-wrapper').length) {
 		 		return;
@@ -63,7 +71,7 @@ jQuery(document).ready(function($) {
 					tbWindow.css({'top': 20 + adminbar_height + 'px','margin-top':'0'});
 			};
 	 }
-	 
+
 	 setInterval(adjustMicWindowSize, 200);
 
 });

--- a/assets/js/microp.js
+++ b/assets/js/microp.js
@@ -20,7 +20,8 @@ jQuery(document).ready(function($) {
 			editedSize: mic_edited_size,
 			previewScale: mic_preview_scale,
 			make2x: $('#mic-make-2x').prop('checked'),
-			mic_quality: $('#micQuality').val() 
+			mic_quality: $('#micQuality').val(),
+			updated_dimensions: updated_dimensions
 		} ,  function(response) {
 			if (response.status == 'ok') {
 				var newImage = new Image();

--- a/lib/ManualImageCropEditorWindow.php
+++ b/lib/ManualImageCropEditorWindow.php
@@ -307,9 +307,14 @@ class ManualImageCropEditorWindow {
 				if (smallPreviewWidth > smallPreviewHeight) {
 					// Landscape Picture
 					smallPreviewHeight = smallPreviewWidth * (1 / aspect);
+
 				} else {
 					// Portrait Picture
 					smallPreviewWidth = smallPreviewHeight * aspect;
+					if (smallPreviewWidth > 180) {
+						smallPreviewWidth = 180;
+						smallPreviewHeight = 180 * (1 / aspect);
+					}
 				}
 
 				// Calculate new margin for .preview-viewbox
@@ -319,25 +324,9 @@ class ManualImageCropEditorWindow {
 					preview_margin = 5;
 				}
 
-				var viewboxWidth = smallPreviewWidth;
-				var viewboxHeight = smallPreviewHeight;
-
-				if (viewboxWidth > 180 || viewboxHeight > 180) {
-					if (viewboxWidth > viewboxHeight) {
-						//landscape
-						viewboxWidth = 180;
-						viewboxHeight = 180 * (1 / aspect);
-					} else {
-						//portrait
-						viewboxHeight = 180;
-						viewboxWidth = 180 * aspect;
-
-					}
-				}
-
 				$('.preview-viewbox').css({
-					width: viewboxWidth + 'px',
-					height: viewboxHeight + 'px',
+					width: smallPreviewWidth + 'px',
+					height: smallPreviewHeight + 'px',
 					marginLeft: preview_margin + 'px'
 				})
 

--- a/lib/ManualImageCropEditorWindow.php
+++ b/lib/ManualImageCropEditorWindow.php
@@ -303,9 +303,12 @@ class ManualImageCropEditorWindow {
 				// Calculate new viewbox size, constrained to 180px
 				smallPreviewWidth = Math.min(smallPreviewWidth, 180);
 				smallPreviewHeight = Math.min(smallPreviewHeight, 180);
+
 				if (smallPreviewWidth > smallPreviewHeight) {
+					// Landscape Picture
 					smallPreviewHeight = smallPreviewWidth * (1 / aspect);
 				} else {
+					// Portrait Picture
 					smallPreviewWidth = smallPreviewHeight * aspect;
 				}
 
@@ -316,9 +319,25 @@ class ManualImageCropEditorWindow {
 					preview_margin = 5;
 				}
 
+				var viewboxWidth = smallPreviewWidth;
+				var viewboxHeight = smallPreviewHeight;
+
+				if (viewboxWidth > 180 || viewboxHeight > 180) {
+					if (viewboxWidth > viewboxHeight) {
+						//landscape
+						viewboxWidth = 180;
+						viewboxHeight = 180 * (1 / aspect);
+					} else {
+						//portrait
+						viewboxHeight = 180;
+						viewboxWidth = 180 * aspect;
+
+					}
+				}
+
 				$('.preview-viewbox').css({
-					width: smallPreviewWidth + 'px',
-					height: smallPreviewHeight + 'px',
+					width: viewboxWidth + 'px',
+					height: viewboxHeight + 'px',
 					marginLeft: preview_margin + 'px'
 				})
 

--- a/lib/ManualImageCropEditorWindow.php
+++ b/lib/ManualImageCropEditorWindow.php
@@ -241,29 +241,31 @@ class ManualImageCropEditorWindow {
 			mic_attachment_id = <?php echo $postId; ?>;
 			mic_edited_size = '<?php echo $editedSize; ?>';
 			mic_preview_scale = <?php echo $previewRatio; ?>;
-			console.log(mic_preview_scale);
+			updated_dimensions = [false, 0, 0]  // [has_been_updated?, width, height]
+
 			$('#mic-make-2x').change(function() {$('#mic-2x-status').toggle()});
 
-			// On change of aspect ratio
+			// Monitor change to image dimension boxes.
 			$('.dimensions-width, .dimensions-height').change(function(){
 				new_width = $('.dimensions-width').val();
 				new_height = $('.dimensions-height').val();
 
-				// Update jcrop aspect ratio
+				updated_dimensions = [true, new_width, new_height];
+
+				// Update jcrop object on change of aspect ratio
 				$('#jcrop_target').Jcrop({
 					onChange: showPreview,
 					onSelect: showPreview,
-					aspectRatio: new_width / new_height,
+					aspectRatio: new_width / new_height
 				}, function() {
 					jcrop_api = this;
 				});
 
-				// Update preview box.
+				// Update preview viewbox.
 				$('#preview').css({
 					width: new_width + 'px',
 					height: new_height + 'px',
 				});
-
 			})
 
 			setTimeout(function() {

--- a/lib/ManualImageCropSettingsPage.php
+++ b/lib/ManualImageCropSettingsPage.php
@@ -70,7 +70,7 @@ class MicSettingsPage
         <div class="wrap">
             <?php screen_icon(); ?>
             <h2><?php _e('Manual Image Crop Settings', 'microp'); ?></h2>           
-            <form method="post" action="<?php echo esc_attr(admin_url('options.php')); ?>" class="mic-settings-page">
+            <form method="post" action="options.php" class="mic-settings-page">
             <?php
                 // This prints out all hidden setting fields
                 settings_fields( 'mic_options_group' );   

--- a/lib/ManualImageCropSettingsPage.php
+++ b/lib/ManualImageCropSettingsPage.php
@@ -70,7 +70,7 @@ class MicSettingsPage
         <div class="wrap">
             <?php screen_icon(); ?>
             <h2><?php _e('Manual Image Crop Settings', 'microp'); ?></h2>           
-            <form method="post" action="options.php" class="mic-settings-page">
+            <form method="post" action="<?php echo admin_url('options.php'); ?>" class="mic-settings-page">
             <?php
                 // This prints out all hidden setting fields
                 settings_fields( 'mic_options_group' );   


### PR DESCRIPTION
Added the ability to change the aspect ratio of the fixed crop box on demand.  I worked on a project where we needed to set different crop aspect ratios under the same image size.  I'm not sure if this is something that you want to merge into your wip branch.

I added two input boxes where the "Target Picture Dimensions" values used to be and upon editing the values, the preview box will adjust and the aspect ratio of the fixed crop box on demand.  I worked on a project where we needed to set different crop aspect ratios under the same image size.  I'm not sure if this is something that you want to merge into your wip branch.

I added two input boxes where the "Target Picture Dimensions" values used to be and upon editing the values, the preview box will adjust and the picture will be cropped accordingly.    

![one](https://cloud.githubusercontent.com/assets/11035426/16094172/00928902-330d-11e6-9e0b-e5eb766ccc46.png)
![two](https://cloud.githubusercontent.com/assets/11035426/16094171/00928d4e-330d-11e6-9ce1-282b8d46ab4f.png)

Commits from your WIP branch and @RadGH 's wp4.5 fork have been merged in as well.
